### PR TITLE
Add driver, car, and manufacturer detail and list views

### DIFF
--- a/taxi/models.py
+++ b/taxi/models.py
@@ -6,6 +6,9 @@ class Manufacturer(models.Model):
     name = models.CharField(max_length=255, unique=True)
     country = models.CharField(max_length=255)
 
+    def __str__(self):
+        return self.name
+
 
 class Driver(AbstractUser):
     license_number = models.CharField(max_length=255, unique=True)

--- a/taxi/urls.py
+++ b/taxi/urls.py
@@ -12,7 +12,9 @@ urlpatterns = [
         "drivers/<int:pk>/", DriverDetailView.as_view(), name="driver-detail"
     ),
     path(
-        "manufacturers/", ManufacturerListView.as_view(), name="manufacturer-list"
+        "manufacturers/",
+        ManufacturerListView.as_view(),
+        name="manufacturer-list"
     ),
 ]
 

--- a/taxi/urls.py
+++ b/taxi/urls.py
@@ -1,9 +1,23 @@
 from django.urls import path
 
-from .views import index
+from .views import index, ManufacturerListView, CarsListView, CarDetailView, \
+    DriverListView, DriverDetailView
 
 urlpatterns = [
     path("", index, name="index"),
+    path(
+        "manufacturers/", ManufacturerListView.as_view(),
+        name="manufacturers"
+    ),
+    path("cars/", CarsListView.as_view(), name="car-list"),
+    path("cars/<int:pk>/", CarDetailView.as_view(), name="car-detail"),
+    path("drivers/", DriverListView.as_view(), name="driver-list"),
+    path(
+        "drivers/<int:pk>/", DriverDetailView.as_view(), name="driver-detail"
+    ),
+    path(
+        "manufacturers/", ManufacturerListView.as_view(), name="manufacturer-list"
+    ),
 ]
 
 app_name = "taxi"

--- a/taxi/urls.py
+++ b/taxi/urls.py
@@ -5,10 +5,6 @@ from .views import index, ManufacturerListView, CarsListView, CarDetailView, \
 
 urlpatterns = [
     path("", index, name="index"),
-    path(
-        "manufacturers/", ManufacturerListView.as_view(),
-        name="manufacturers"
-    ),
     path("cars/", CarsListView.as_view(), name="car-list"),
     path("cars/<int:pk>/", CarDetailView.as_view(), name="car-detail"),
     path("drivers/", DriverListView.as_view(), name="driver-list"),

--- a/taxi/views.py
+++ b/taxi/views.py
@@ -1,5 +1,3 @@
-from symtable import Class
-
 from django.shortcuts import render
 from django.views import generic
 

--- a/taxi/views.py
+++ b/taxi/views.py
@@ -1,4 +1,7 @@
+from symtable import Class
+
 from django.shortcuts import render
+from django.views import generic
 
 from taxi.models import Driver, Car, Manufacturer
 
@@ -13,3 +16,36 @@ def index(request):
     }
 
     return render(request, "taxi/index.html", context=context)
+
+
+class ManufacturerListView(generic.ListView):
+    model = Manufacturer
+    queryset = Manufacturer.objects.all().order_by("name")
+    paginate_by = 5
+    context_object_name = "manufacturer_list"
+
+
+class CarsListView(generic.ListView):
+    model = Car
+    queryset = Car.objects.select_related("manufacturer").order_by("id")
+    paginate_by = 5
+    context_object_name = "car_list"
+
+
+class CarDetailView(generic.DetailView):
+    model = Car
+    queryset = Car.objects.prefetch_related("drivers")
+
+
+class DriverListView(generic.ListView):
+    model = Driver
+    queryset = Driver.objects.all().order_by("id")
+    paginate_by = 5
+    context_object_name = "driver_list"
+
+
+class DriverDetailView(generic.DetailView):
+    model = Driver
+    queryset = Driver.objects.prefetch_related(
+        "cars__manufacturer"
+    ).order_by("id")

--- a/taxi_service/settings.py
+++ b/taxi_service/settings.py
@@ -22,7 +22,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-8ovil3xu6=eaoqd#-#&ricv159poh5_lgm*)-dfcjqe=yc"
 
-# SECURITY WARNING: don"t run with debug turned on in production!
+# SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
 ALLOWED_HOSTS = []

--- a/templates/base.html
+++ b/templates/base.html
@@ -29,6 +29,9 @@
       {% block content %}{% endblock %}
 
       {% block pagination %}
+        {% if page_obj %}
+        	{% include "includes/pagination.html" %}
+        {% endif %} 
       {% endblock %}
 
     </div>

--- a/templates/includes/pagination.html
+++ b/templates/includes/pagination.html
@@ -1,0 +1,27 @@
+{% if is_paginated %}
+  <ul class="pagination">
+  
+    {% if page_obj.has_previous %}
+      <li class="page-item">
+        <a href="?page= {{ page_obj.previous_page_number }}" class="page-link">
+          prev
+        </a>
+      </li>
+    {% endif %}
+
+    <li class="page-item active">
+      <span class="page-link">
+        {{ page_obj.number }} of {{ paginator.num_pages }}
+      </span>
+    </li>
+
+    {% if page_obj.has_next %}
+      <li class="page-item">
+        <a href="?page= {{ page_obj.next_page_number }}" class="page-link">
+          next
+        </a>
+      </li>
+    {% endif %}
+  
+  </ul>
+{% endif %}

--- a/templates/includes/pagination.html
+++ b/templates/includes/pagination.html
@@ -3,7 +3,7 @@
   
     {% if page_obj.has_previous %}
       <li class="page-item">
-        <a href="?page= {{ page_obj.previous_page_number }}" class="page-link">
+        <a href="?page={{ page_obj.previous_page_number }}" class="page-link">
           prev
         </a>
       </li>
@@ -17,7 +17,7 @@
 
     {% if page_obj.has_next %}
       <li class="page-item">
-        <a href="?page= {{ page_obj.next_page_number }}" class="page-link">
+        <a href="?page={{ page_obj.next_page_number }}" class="page-link">
           next
         </a>
       </li>

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -1,6 +1,6 @@
 <ul class="sidebar-nav">
-  <li><a href="#">Home page</a></li>
-  <li><a href="#">Manufacturers</a></li>
-  <li><a href="#">Cars</a></li>
-  <li><a href="#">Drivers</a></li>
+  <li><a href="{% url "taxi:index" %}">Home page</a></li>
+  <li><a href="{% url "taxi:manufacturer-list" %}">Manufacturers</a></li>
+  <li><a href="{% url "taxi:car-list" %}">Cars</a></li>
+  <li><a href="{% url "taxi:driver-list" %}">Drivers</a></li>
 </ul>

--- a/templates/taxi/car_detail.html
+++ b/templates/taxi/car_detail.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+  <table class="table table-striped table-bordered table-hover">
+    <thead>
+    <tr>
+      <th>Manufacturer name</th>
+      <th>Manufacturer country</th>
+      <th>Car's driver</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>{{ car.manufacturer.name }}</td>
+      <td>{{ car.manufacturer.country }}</td>
+      <td>
+        {% for driver in car.drivers.all %}
+          {{ driver.first_name }}
+          {{ driver.last_name }}{% if not forloop.last %}<br> {% endif %}
+          {% empty %}
+          No data available
+        {% endfor %}
+      </td>
+    </tbody>
+  </table>
+{% endblock %}

--- a/templates/taxi/car_detail.html
+++ b/templates/taxi/car_detail.html
@@ -13,7 +13,7 @@
       <td>{{ car.manufacturer.name }}</td>
       <td>{{ car.manufacturer.country }}</td>
       <td>
-        {% for driver in car.drivers.all %}
+        {% for driver in car.drivers.all() %}
           {{ driver.first_name }}
           {{ driver.last_name }}{% if not forloop.last %}<br> {% endif %}
           {% empty %}

--- a/templates/taxi/car_detail.html
+++ b/templates/taxi/car_detail.html
@@ -13,7 +13,7 @@
       <td>{{ car.manufacturer.name }}</td>
       <td>{{ car.manufacturer.country }}</td>
       <td>
-        {% for driver in car.drivers.all() %}
+        {% for driver in car.drivers.all %}
           {{ driver.first_name }}
           {{ driver.last_name }}{% if not forloop.last %}<br> {% endif %}
           {% empty %}

--- a/templates/taxi/car_list.html
+++ b/templates/taxi/car_list.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+  <table class="table table-striped table-bordered">
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>Model</th>
+      <th>Manufacturer</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for car in car_list %}
+      <tr>
+        <td><a href="{% url "taxi:car-detail" car.id %}">{{ car.id }}</a></td>
+        <td>{{ car.model }}</td>
+        <td>{{ car.manufacturer }}</td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="3">No cars available</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/templates/taxi/driver_detail.html
+++ b/templates/taxi/driver_detail.html
@@ -9,7 +9,7 @@
     </tr>
     </thead>
     <tbody>
-      {% for car in driver.cars.all() %}
+      {% for car in driver.cars.all %}
         <tr>
           <td>{{ car.model }}</td>
           <td>{{ car.manufacturer.name }}</td>

--- a/templates/taxi/driver_detail.html
+++ b/templates/taxi/driver_detail.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Driver's car</h2>
+  <table class="table table-striped table-bordered">
+    <thead>
+    <tr>
+      <th>Driver's car model</th>
+      <th>Driver's manufacturer</th>
+    </tr>
+    </thead>
+    <tbody>
+      {% for car in driver.cars.all %}
+        <tr>
+          <td>{{ car.model }}</td>
+          <td>{{ car.manufacturer.name }}</td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="2">The driver doesn't a car</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}

--- a/templates/taxi/driver_detail.html
+++ b/templates/taxi/driver_detail.html
@@ -9,14 +9,14 @@
     </tr>
     </thead>
     <tbody>
-      {% for car in driver.cars.all %}
+      {% for car in driver.cars.all() %}
         <tr>
           <td>{{ car.model }}</td>
           <td>{{ car.manufacturer.name }}</td>
         </tr>
         {% empty %}
         <tr>
-          <td colspan="2">The driver doesn't a car</td>
+          <td colspan="2">The driver doesn't have a car</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/templates/taxi/driver_list.html
+++ b/templates/taxi/driver_list.html
@@ -25,7 +25,7 @@
       </tr>
       {% empty %}
       <tr>
-        <td colspan="5"></td>
+        <td colspan="5">There are no drivers available</td>
       </tr>
     {% endfor %}
 

--- a/templates/taxi/driver_list.html
+++ b/templates/taxi/driver_list.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block content %}
+  <table class="table table-striped table-bordered">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Username driver</th>
+        <th>First name</th>
+        <th>Last name</th>
+        <th>License number</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for driver in driver_list %}
+      <tr>
+        <td>{{ driver.id }}</td>
+        <td>
+          <a href="{% url "taxi:driver-detail" driver.id %}">
+            {{ driver.username }}
+          </a>
+        </td>
+        <td>{{ driver.first_name }}</td>
+        <td>{{ driver.last_name }}</td>
+        <td>{{ driver.license_number }}</td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="5"></td>
+      </tr>
+    {% endfor %}
+
+    </tbody>
+  </table>
+{% endblock %}

--- a/templates/taxi/manufacturer_list.html
+++ b/templates/taxi/manufacturer_list.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+  <table class="table table-striped table-bordered">
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>Name</th>
+      <th>Country</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for manufacturer in manufacturer_list %}
+      <tr>
+        <td>{{ manufacturer.id }}</td>
+        <td>{{ manufacturer.name }}</td>
+        <td>{{ manufacturer.country }}</td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="3">No manufacturers available.</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}


### PR DESCRIPTION
Implemented views and templates for driver, car, and manufacturer details and lists. Enhanced base template with pagination includes and fixed URL links in the sidebar.
![ss_1](https://github.com/user-attachments/assets/4bca2273-b560-44ec-89a4-9b9d02e04601)
![ss_2](https://github.com/user-attachments/assets/49f80930-3874-4996-84de-1f0cb8b14f35)
![ss_3](https://github.com/user-attachments/assets/da94d3ea-2c09-428d-83cd-b3682ea2951c)
![ss_4](https://github.com/user-attachments/assets/3c561cf8-151c-4b57-bb67-cde4969a1931)
![ss_5](https://github.com/user-attachments/assets/e293c61c-1075-437e-9027-7b4aff56f2f1)
